### PR TITLE
Fix property RegEx

### DIFF
--- a/src/se/vidstige/jadb/managers/PropertyManager.java
+++ b/src/se/vidstige/jadb/managers/PropertyManager.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  * A class which works with properties, uses getprop and setprop methods of android shell
  */
 public class PropertyManager {
-    private final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]*)\\]:.\\[([^\\[\\]]*)\\]");
+    private final Pattern pattern = Pattern.compile("^\\[([a-zA-Z0-9_.-]+)]: \\[([^]]*)]");
     private final JadbDevice device;
 
     public PropertyManager(JadbDevice device) {


### PR DESCRIPTION
Removed redundant escapes
Require non-empty key value (group 1) using '+' instead of '*'
Match [:space:] explicitly as separator between key and value.
Match value as "all until next right square bracket". 
This matching is far more relaxed and less likely to exclude properties by accident.

Test case:
    [ro.product.model]: [Pixel XL]

Without this change, the property is skipped.